### PR TITLE
Display API errors to end users

### DIFF
--- a/QStreak.xcodeproj/project.pbxproj
+++ b/QStreak.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		D5048B012440B33A0029AE0C /* Date+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5048B002440B33A0029AE0C /* Date+Extensions.swift */; };
 		D52E58A02448A1EB00A0C2FA /* DailyStat.swift in Sources */ = {isa = PBXBuildFile; fileRef = D52E589F2448A1EB00A0C2FA /* DailyStat.swift */; };
 		D578745424477DC800AFC30D /* RecordTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D578745324477DC800AFC30D /* RecordTableViewCell.swift */; };
+		D5B1F860244F93860083DB6C /* APIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B1F85F244F93860083DB6C /* APIError.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -111,6 +112,7 @@
 		D5048B002440B33A0029AE0C /* Date+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extensions.swift"; sourceTree = "<group>"; };
 		D52E589F2448A1EB00A0C2FA /* DailyStat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyStat.swift; sourceTree = "<group>"; };
 		D578745324477DC800AFC30D /* RecordTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordTableViewCell.swift; sourceTree = "<group>"; };
+		D5B1F85F244F93860083DB6C /* APIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIError.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -215,6 +217,7 @@
 		9955F966243FDFD000077C58 /* Networking */ = {
 			isa = PBXGroup;
 			children = (
+				D5B1F85F244F93860083DB6C /* APIError.swift */,
 				9955F967243FE00F00077C58 /* NetworkService.swift */,
 				9955F969243FE03700077C58 /* HTTPMethod.swift */,
 				9955F96D243FE0D600077C58 /* ParameterEncoding.swift */,
@@ -485,6 +488,7 @@
 				990B4552243E510D00177002 /* Activity.swift in Sources */,
 				9955F972243FE34200077C58 /* URLRequest+Extensions.swift in Sources */,
 				990B454E243E4E5D00177002 /* RecordListViewModel.swift in Sources */,
+				D5B1F860244F93860083DB6C /* APIError.swift in Sources */,
 				D578745424477DC800AFC30D /* RecordTableViewCell.swift in Sources */,
 				9955F97A243FE6BC00077C58 /* Networkable.swift in Sources */,
 				9955F970243FE13C00077C58 /* URLComponents+Extensions.swift in Sources */,

--- a/QStreak.xcodeproj/project.pbxproj
+++ b/QStreak.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		D52E58A02448A1EB00A0C2FA /* DailyStat.swift in Sources */ = {isa = PBXBuildFile; fileRef = D52E589F2448A1EB00A0C2FA /* DailyStat.swift */; };
 		D578745424477DC800AFC30D /* RecordTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D578745324477DC800AFC30D /* RecordTableViewCell.swift */; };
 		D5B1F860244F93860083DB6C /* APIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B1F85F244F93860083DB6C /* APIError.swift */; };
+		D5B1F8672450BE410083DB6C /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B1F8662450BE410083DB6C /* String+Extensions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -113,6 +114,7 @@
 		D52E589F2448A1EB00A0C2FA /* DailyStat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyStat.swift; sourceTree = "<group>"; };
 		D578745324477DC800AFC30D /* RecordTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordTableViewCell.swift; sourceTree = "<group>"; };
 		D5B1F85F244F93860083DB6C /* APIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIError.swift; sourceTree = "<group>"; };
+		D5B1F8662450BE410083DB6C /* String+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -300,6 +302,7 @@
 			isa = PBXGroup;
 			children = (
 				D5048B002440B33A0029AE0C /* Date+Extensions.swift */,
+				D5B1F8662450BE410083DB6C /* String+Extensions.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -471,6 +474,7 @@
 				992249BB2440F92800A4790A /* QStreakService.swift in Sources */,
 				9955F968243FE00F00077C58 /* NetworkService.swift in Sources */,
 				D5048AFC243F90790029AE0C /* RecordDetailViewModel.swift in Sources */,
+				D5B1F8672450BE410083DB6C /* String+Extensions.swift in Sources */,
 				990B4545243E465900177002 /* AccountSetupViewController.swift in Sources */,
 				990B454C243E4E4F00177002 /* RecordListViewController.swift in Sources */,
 				D5048B012440B33A0029AE0C /* Date+Extensions.swift in Sources */,

--- a/QStreak/AppDelegate.swift
+++ b/QStreak/AppDelegate.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 @UIApplicationMain
-class AppDelegate: UIResponder, UIApplicationDelegate {
+ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.

--- a/QStreak/AppDelegate.swift
+++ b/QStreak/AppDelegate.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 @UIApplicationMain
- class AppDelegate: UIResponder, UIApplicationDelegate {
+class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.

--- a/QStreak/Networking/APIError.swift
+++ b/QStreak/Networking/APIError.swift
@@ -12,8 +12,7 @@ struct APIError: Decodable {
     var errors: [String:[String]]
 
     func message() -> String {
-        let msg = self.errors.map { "\($0.key) \($0.value.joined(separator: ", "))." }
-        return "Error processing request: \(msg.joined(separator: " "))"
+        return self.errors.map { "\($0.key) \($0.value.joined(separator: ", "))" }
+                          .joined(separator: " ")
     }
 }
-

--- a/QStreak/Networking/APIError.swift
+++ b/QStreak/Networking/APIError.swift
@@ -12,7 +12,7 @@ struct APIError: Decodable {
     var errors: [String:[String]]
 
     func message() -> String {
-        return self.errors.map { "\($0.key) \($0.value.joined(separator: ", "))" }
+        return self.errors.map { "\($0.key.camelCaseToWords()) \($0.value.joined(separator: ", "))" }
                           .joined(separator: " ")
     }
 }

--- a/QStreak/Networking/APIError.swift
+++ b/QStreak/Networking/APIError.swift
@@ -12,7 +12,7 @@ struct APIError: Decodable {
     var errors: [String:[String]]
 
     func message() -> String {
-        return self.errors.map { "\($0.key.camelCaseToWords()) \($0.value.joined(separator: ", "))" }
+        return self.errors.map { "\($0.key.snakeCaseToWords()) \($0.value.joined(separator: ", "))" }
                           .joined(separator: " ")
     }
 }

--- a/QStreak/Networking/APIError.swift
+++ b/QStreak/Networking/APIError.swift
@@ -1,0 +1,19 @@
+//
+//  APIError.swift
+//  QStreak
+//
+//  Created by Daniel McCoy on 4/21/20.
+//  Copyright © 2020 Rocket Insights. All rights reserved.
+//
+
+import Foundation
+
+struct APIError: Decodable {
+    var errors: [String:[String]]
+
+    func message() -> String {
+        let msg = self.errors.map { "\($0.key) \($0.value.joined(separator: ", "))." }
+        return "Error processing request: \(msg.joined(separator: " "))"
+    }
+}
+

--- a/QStreak/Networking/NetworkError.swift
+++ b/QStreak/Networking/NetworkError.swift
@@ -14,6 +14,8 @@ enum NetworkError: Error {
     case failedJSONDecoding
     case failedBuildingURLRequest
     case malformedRequest(message: String)
+    case unauthorized
+    case badRequest
 }
 
 extension NetworkError {
@@ -21,15 +23,14 @@ extension NetworkError {
         switch self {
         case .unknown:
             return "An unknown error has occured. Please try again later..."
-        case .noJSONData:
-            return ". Please try again later..."
-        case .failedJSONDecoding:
-            return "Malformed response from server. Please try again later..."
-        case .failedBuildingURLRequest:
+        case .noJSONData, .badRequest:
+            return "Bad request. Please try again later..."
+        case .failedJSONDecoding, .failedBuildingURLRequest:
             return "Unable to access server. Please try again later..."
         case .malformedRequest(let message):
-            return "Unsuccessful request: \(message). Please correct errors and try again."
-            
+            return "\(message). Please correct errors and try again."
+        case .unauthorized:
+            return "Account cannot be found or you are unauthorized to take that action."
         }
     }
 }

--- a/QStreak/Networking/NetworkError.swift
+++ b/QStreak/Networking/NetworkError.swift
@@ -15,3 +15,21 @@ enum NetworkError: Error {
     case failedBuildingURLRequest
     case malformedRequest(message: String)
 }
+
+extension NetworkError {
+    var message: String {
+        switch self {
+        case .unknown:
+            return "An unknown error has occured. Please try again later..."
+        case .noJSONData:
+            return ". Please try again later..."
+        case .failedJSONDecoding:
+            return "Malformed response from server. Please try again later..."
+        case .failedBuildingURLRequest:
+            return "Unable to access server. Please try again later..."
+        case .malformedRequest(let message):
+            return "Unsuccessful request: \(message). Please correct errors and try again."
+            
+        }
+    }
+}

--- a/QStreak/Networking/NetworkError.swift
+++ b/QStreak/Networking/NetworkError.swift
@@ -13,5 +13,5 @@ enum NetworkError: Error {
     case noJSONData
     case failedJSONDecoding
     case failedBuildingURLRequest
-    case malformedRequest
+    case malformedRequest(message: String)
 }

--- a/QStreak/Networking/URLSessionProvider.swift
+++ b/QStreak/Networking/URLSessionProvider.swift
@@ -41,8 +41,6 @@ final class URLSessionProvider: NetworkProvider {
             guard let data = data,
                 let apiError = try? JSONDecoder().decode(APIError.self, from: data)
                 else { return completion(.failure(.failedJSONDecoding)) }
-            
-            print(apiError)
 
             completion(.failure(.malformedRequest(message: apiError.message())))
         default:

--- a/QStreak/Networking/URLSessionProvider.swift
+++ b/QStreak/Networking/URLSessionProvider.swift
@@ -38,7 +38,13 @@ final class URLSessionProvider: NetworkProvider {
 
             completion(.success(model))
         case 400...499:
-            completion(.failure(.malformedRequest))
+            guard let data = data,
+                let apiError = try? JSONDecoder().decode(APIError.self, from: data)
+                else { return completion(.failure(.failedJSONDecoding)) }
+            
+            print(apiError)
+
+            completion(.failure(.malformedRequest(message: apiError.message())))
         default:
             completion(.failure(.unknown))
         }

--- a/QStreak/Networking/URLSessionProvider.swift
+++ b/QStreak/Networking/URLSessionProvider.swift
@@ -37,7 +37,11 @@ final class URLSessionProvider: NetworkProvider {
                 else { return completion(.failure(.failedJSONDecoding)) }
 
             completion(.success(model))
-        case 400...499:
+        case 400:
+            completion(.failure(.badRequest))
+        case 401:
+            completion(.failure(.unauthorized))
+        case 422:
             guard let data = data,
                 let apiError = try? JSONDecoder().decode(APIError.self, from: data)
                 else { return completion(.failure(.failedJSONDecoding)) }

--- a/QStreak/Utilities/String+Extensions.swift
+++ b/QStreak/Utilities/String+Extensions.swift
@@ -9,8 +9,8 @@
 import Foundation
 
 extension String {
-    func camelCaseToWords() -> String {
-        return self.replacingOccurrences(of: "_", with: " ", options: .regularExpression)
+    func snakeCaseToWords() -> String {
+        return self.replacingOccurrences(of: "_", with: " ")
                    .capitalized
     }
 }

--- a/QStreak/Utilities/String+Extensions.swift
+++ b/QStreak/Utilities/String+Extensions.swift
@@ -1,0 +1,16 @@
+//
+//  String+Extensions.swift
+//  QStreak
+//
+//  Created by Daniel McCoy on 4/22/20.
+//  Copyright © 2020 Rocket Insights. All rights reserved.
+//
+
+import Foundation
+
+extension String {
+    func camelCaseToWords() -> String {
+        return self.replacingOccurrences(of: "_", with: " ", options: .regularExpression)
+                   .capitalized
+    }
+}

--- a/QStreak/View Controllers/Account Setup/AccountSetupViewController.swift
+++ b/QStreak/View Controllers/Account Setup/AccountSetupViewController.swift
@@ -50,4 +50,15 @@ extension AccountSetupViewController: AccountSetupViewModelDelegate {
 
         navigationController?.pushViewController(addRecordViewController, animated: true)
     }
+
+    func failedAccountCreation(error: NetworkError) {
+        DispatchQueue.main.async {
+            let alert = UIAlertController(title: "Request Unsuccessful", message: error.message, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: "Default action"), style: .default, handler: { _ in
+                NSLog("The \"OK\" alert occured.")
+            }))
+
+            self.present(alert, animated: true, completion: nil)
+        }
+    }
 }

--- a/QStreak/View Controllers/Account Setup/AccountSetupViewController.swift
+++ b/QStreak/View Controllers/Account Setup/AccountSetupViewController.swift
@@ -53,8 +53,8 @@ extension AccountSetupViewController: AccountSetupViewModelDelegate {
 
     func failedAccountCreation(error: NetworkError) {
         DispatchQueue.main.async {
-            let alert = UIAlertController(title: "Unable to create account", message: error.message, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: "OK", style: .default))
+            let alert = UIAlertController(title: self.viewModel.alertTitleText, message: error.message, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: self.viewModel.alertDismissButtonText, style: .default))
 
             self.present(alert, animated: true, completion: nil)
         }

--- a/QStreak/View Controllers/Account Setup/AccountSetupViewController.swift
+++ b/QStreak/View Controllers/Account Setup/AccountSetupViewController.swift
@@ -53,10 +53,8 @@ extension AccountSetupViewController: AccountSetupViewModelDelegate {
 
     func failedAccountCreation(error: NetworkError) {
         DispatchQueue.main.async {
-            let alert = UIAlertController(title: "Request Unsuccessful", message: error.message, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: "Default action"), style: .default, handler: { _ in
-                NSLog("The \"OK\" alert occured.")
-            }))
+            let alert = UIAlertController(title: "Unable to create account", message: error.message, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "OK", style: .default))
 
             self.present(alert, animated: true, completion: nil)
         }

--- a/QStreak/View Controllers/Account Setup/AccountSetupViewModel.swift
+++ b/QStreak/View Controllers/Account Setup/AccountSetupViewModel.swift
@@ -10,6 +10,7 @@ import Foundation
 
 protocol AccountSetupViewModelDelegate: AnyObject {
     func showAddRecordViewController()
+    func failedAccountCreation(error: NetworkError)
 }
 
 class AccountSetupViewModel {
@@ -35,7 +36,7 @@ class AccountSetupViewModel {
                     self?.delegate?.showAddRecordViewController()
                 }
             case let .failure(error):
-                print(error)
+                self?.delegate?.failedAccountCreation(error: error)
             }
         }
     }

--- a/QStreak/View Controllers/Account Setup/AccountSetupViewModel.swift
+++ b/QStreak/View Controllers/Account Setup/AccountSetupViewModel.swift
@@ -15,6 +15,9 @@ protocol AccountSetupViewModelDelegate: AnyObject {
 
 class AccountSetupViewModel {
 
+    let alertTitleText = "Unable to create account"
+    let alertDismissButtonText =  "OK"
+
     private let sessionProvider = URLSessionProvider()
 
     weak var delegate: AccountSetupViewModelDelegate?

--- a/QStreak/View Controllers/Add Record/AddRecordViewController.swift
+++ b/QStreak/View Controllers/Add Record/AddRecordViewController.swift
@@ -96,10 +96,8 @@ extension AddRecordViewController: AddRecordViewModelDelegate {
 
     func failedSubmission(error: NetworkError) {
         DispatchQueue.main.async {
-            let alert = UIAlertController(title: "Request Unsuccessful", message: error.message, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: "Default action"), style: .default, handler: { _ in
-                NSLog("The \"OK\" alert occured.")
-            }))
+            let alert = UIAlertController(title: "Unable to create submission", message: error.message, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "OK", style: .default))
 
             self.present(alert, animated: true, completion: nil)
         }

--- a/QStreak/View Controllers/Add Record/AddRecordViewController.swift
+++ b/QStreak/View Controllers/Add Record/AddRecordViewController.swift
@@ -96,8 +96,8 @@ extension AddRecordViewController: AddRecordViewModelDelegate {
 
     func failedSubmission(error: NetworkError) {
         DispatchQueue.main.async {
-            let alert = UIAlertController(title: "Unable to create submission", message: error.message, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: "OK", style: .default))
+            let alert = UIAlertController(title: self.viewModel.alertTitleText, message: error.message, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: self.viewModel.alertDismissButtonText, style: .default))
 
             self.present(alert, animated: true, completion: nil)
         }

--- a/QStreak/View Controllers/Add Record/AddRecordViewController.swift
+++ b/QStreak/View Controllers/Add Record/AddRecordViewController.swift
@@ -93,4 +93,15 @@ extension AddRecordViewController: AddRecordViewModelDelegate {
             }
         }
     }
+
+    func failedSubmission(error: NetworkError) {
+        DispatchQueue.main.async {
+            let alert = UIAlertController(title: "Request Unsuccessful", message: error.message, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: "Default action"), style: .default, handler: { _ in
+                NSLog("The \"OK\" alert occured.")
+            }))
+
+            self.present(alert, animated: true, completion: nil)
+        }
+    }
 }

--- a/QStreak/View Controllers/Add Record/AddRecordViewModel.swift
+++ b/QStreak/View Controllers/Add Record/AddRecordViewModel.swift
@@ -18,6 +18,9 @@ class AddRecordViewModel {
 
     // MARK: - Properties
 
+    let alertTitleText = "Unable to create submission"
+    let alertDismissButtonText =  "OK"
+
     private let sessionProvider = URLSessionProvider()
 
     weak var delegate: AddRecordViewModelDelegate?

--- a/QStreak/View Controllers/Add Record/AddRecordViewModel.swift
+++ b/QStreak/View Controllers/Add Record/AddRecordViewModel.swift
@@ -55,7 +55,7 @@ class AddRecordViewModel {
                 let recordDetailViewModel = RecordDetailViewModel.init(record: submission)
                 self?.delegate?.addedSubmission(record: recordDetailViewModel)
             case .failure(let error):
-                print(error)
+                print(error.message)
             }
         }
     }

--- a/QStreak/View Controllers/Add Record/AddRecordViewModel.swift
+++ b/QStreak/View Controllers/Add Record/AddRecordViewModel.swift
@@ -11,6 +11,7 @@ import Foundation
 protocol AddRecordViewModelDelegate: AnyObject {
     func retrievedDestinations()
     func addedSubmission(record: RecordDetailViewModel)
+    func failedSubmission(error: NetworkError)
 }
 
 class AddRecordViewModel {
@@ -55,7 +56,7 @@ class AddRecordViewModel {
                 let recordDetailViewModel = RecordDetailViewModel.init(record: submission)
                 self?.delegate?.addedSubmission(record: recordDetailViewModel)
             case .failure(let error):
-                print(error.message)
+                self?.delegate?.failedSubmission(error: error)
             }
         }
     }

--- a/QStreak/View Controllers/Record List/RecordListViewController.swift
+++ b/QStreak/View Controllers/Record List/RecordListViewController.swift
@@ -118,8 +118,14 @@ extension RecordListViewController: RecordListViewModelDelegate {
         }
     }
 
-    func onFetchFailed(with reason: String) {
-        // TODO - Handle failed request
-        print(reason)
+    func onFetchFailed(error: NetworkError) {
+        DispatchQueue.main.async {
+            let alert = UIAlertController(title: "Request Unsuccessful", message: error.message, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: "Default action"), style: .default, handler: { _ in
+                NSLog("The \"OK\" alert occured.")
+            }))
+
+            self.present(alert, animated: true, completion: nil)
+        }
     }
 }

--- a/QStreak/View Controllers/Record List/RecordListViewController.swift
+++ b/QStreak/View Controllers/Record List/RecordListViewController.swift
@@ -120,8 +120,8 @@ extension RecordListViewController: RecordListViewModelDelegate {
 
     func onFetchFailed(error: NetworkError) {
         DispatchQueue.main.async {
-            let alert = UIAlertController(title: "Unable to fetch submissions", message: error.message, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: "OK", style: .default))
+            let alert = UIAlertController(title: self.viewModel.alertTitleText, message: error.message, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: self.viewModel.alertDismissButtonText, style: .default))
 
             self.present(alert, animated: true, completion: nil)
         }

--- a/QStreak/View Controllers/Record List/RecordListViewController.swift
+++ b/QStreak/View Controllers/Record List/RecordListViewController.swift
@@ -120,10 +120,8 @@ extension RecordListViewController: RecordListViewModelDelegate {
 
     func onFetchFailed(error: NetworkError) {
         DispatchQueue.main.async {
-            let alert = UIAlertController(title: "Request Unsuccessful", message: error.message, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: "Default action"), style: .default, handler: { _ in
-                NSLog("The \"OK\" alert occured.")
-            }))
+            let alert = UIAlertController(title: "Unable to fetch submissions", message: error.message, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "OK", style: .default))
 
             self.present(alert, animated: true, completion: nil)
         }

--- a/QStreak/View Controllers/Record List/RecordListViewModel.swift
+++ b/QStreak/View Controllers/Record List/RecordListViewModel.swift
@@ -16,6 +16,10 @@ protocol RecordListViewModelDelegate: AnyObject {
 
 class RecordListViewModel {
     // MARK: - Properties
+
+    let alertTitleText = "Unable to fetch submissions"
+    let alertDismissButtonText =  "OK"
+
     var records: [Submission?] = []
     var currentPage = 1
     var totalPages = 1

--- a/QStreak/View Controllers/Record List/RecordListViewModel.swift
+++ b/QStreak/View Controllers/Record List/RecordListViewModel.swift
@@ -11,7 +11,7 @@ import Foundation
 protocol RecordListViewModelDelegate: AnyObject {
     func showRecordDetailViewController(recordDetailViewModel: RecordDetailViewModel)
     func onFetchCompleted(with newIndexPathsToReload: [IndexPath]?)
-    func onFetchFailed(with reason: String)
+    func onFetchFailed(error: NetworkError)
 }
 
 class RecordListViewModel {
@@ -59,7 +59,7 @@ class RecordListViewModel {
             case let .failure(error):
                 DispatchQueue.main.async {
                     self?.isFetchInProgress = false
-                    self?.delegate?.onFetchFailed(with: error.localizedDescription)
+                    self?.delegate?.onFetchFailed(error: error)
                 }
             }
         }


### PR DESCRIPTION
I've updated functionality related to API calls to display feedback to ends users in the form of an alert when an API call fails.

![Simulator Screen Shot - iPhone 11 Pro Max - 2020-04-22 at 14 09 41](https://user-images.githubusercontent.com/3976685/80032581-62d27f80-84b9-11ea-829a-6eb89f9a316f.png)
![Simulator Screen Shot - iPhone 11 Pro Max - 2020-04-22 at 14 10 18](https://user-images.githubusercontent.com/3976685/80032583-636b1600-84b9-11ea-8fed-c38913aae7fc.png)
![Simulator Screen Shot - iPhone 11 Pro Max - 2020-04-22 at 14 19 56](https://user-images.githubusercontent.com/3976685/80032585-636b1600-84b9-11ea-849a-94ea076e4190.png)


