### PR TITLE
Allow users to delete submissions

### DIFF
--- a/QStreak/Networking/NetworkProvider.swift
+++ b/QStreak/Networking/NetworkProvider.swift
@@ -9,5 +9,5 @@
 import Foundation
 
 protocol NetworkProvider {
-    func request<T>(type: T.Type, service: NetworkService, completion: @escaping (Result<T, NetworkError>) -> Void) where T: Decodable
+    func request<T>(type: T.Type, service: NetworkService, completion: @escaping (Result<T?, NetworkError>) -> Void) where T: Decodable
 }

--- a/QStreak/Networking/QStreakService.swift
+++ b/QStreak/Networking/QStreakService.swift
@@ -13,6 +13,7 @@ enum QstreakService {
     case createSubmission(contactCount: Int, date: String, destinations: [String])
     case getDestinations
     case getSubmissions(page: Int)
+    case deleteSubmission(submissionId: Int)
 
     var uuid: String { return UserDefaults.standard.string(forKey: "uuid") ?? "" }
 }
@@ -33,6 +34,8 @@ extension QstreakService: NetworkService {
             return "/api/submissions"
         case .getDestinations:
             return "/api/destinations"
+        case .deleteSubmission(let submissionId):
+            return "/api/submissions/\(submissionId)"
         }
     }
 
@@ -42,6 +45,8 @@ extension QstreakService: NetworkService {
             return .post
         case .getDestinations, .getSubmissions:
             return .get
+        case .deleteSubmission:
+            return .delete
         }
     }
 
@@ -49,7 +54,7 @@ extension QstreakService: NetworkService {
         switch self {
         case .signUp:
             return ["Content-Type": "application/json"]
-        case .createSubmission, .getDestinations, .getSubmissions:
+        case .createSubmission, .getDestinations, .getSubmissions, .deleteSubmission:
             return ["Content-Type": "application/json",
                     "authorization": "bearer \(uuid)"]
         }
@@ -67,7 +72,7 @@ extension QstreakService: NetworkService {
                                    "destination_slugs": destinations]]
         case .getSubmissions(let page):
             return [ "page": page, "page_size": 20 ]
-        case .getDestinations:
+        case .getDestinations, .deleteSubmission:
           return nil
         }
     }
@@ -76,7 +81,7 @@ extension QstreakService: NetworkService {
         switch self {
         case .signUp, .createSubmission:
             return .json
-        case .getSubmissions, .getDestinations:
+        case .getSubmissions, .getDestinations, .deleteSubmission:
             return .url
         }
     }

--- a/QStreak/View Controllers/Account Setup/AccountSetupViewModel.swift
+++ b/QStreak/View Controllers/Account Setup/AccountSetupViewModel.swift
@@ -34,9 +34,11 @@ class AccountSetupViewModel {
         sessionProvider.request(type: User.self, service: QstreakService.signUp(age: age, householdSize: householdSize, zipCode: zipCode)) { [weak self] result in
             switch result {
             case let .success(user):
-                UserDefaults.standard.set(user.uuid, forKey: "uuid")
-                DispatchQueue.main.async {
-                    self?.delegate?.showAddRecordViewController()
+                if let user = user {
+                    UserDefaults.standard.set(user.uuid, forKey: "uuid")
+                    DispatchQueue.main.async {
+                        self?.delegate?.showAddRecordViewController()
+                    }
                 }
             case let .failure(error):
                 self?.delegate?.failedAccountCreation(error: error)

--- a/QStreak/View Controllers/Add Record/AddRecordViewModel.swift
+++ b/QStreak/View Controllers/Add Record/AddRecordViewModel.swift
@@ -33,8 +33,10 @@ class AddRecordViewModel {
         sessionProvider.request(type: [Activity].self, service: QstreakService.getDestinations) { [weak self] result in
             switch result {
             case .success(let activities):
-                self?.categories = activities
-                self?.delegate?.retrievedDestinations()
+                if let activities = activities {
+                    self?.categories = activities
+                    self?.delegate?.retrievedDestinations()
+                }
             case .failure(let error):
                 print(error)
             }
@@ -56,8 +58,10 @@ class AddRecordViewModel {
         sessionProvider.request(type: Submission.self, service: QstreakService.createSubmission(contactCount: contactCount, date: date.formattedDate, destinations: destinations)) { [weak self ] result in
             switch result {
             case .success(let submission):
-                let recordDetailViewModel = RecordDetailViewModel.init(record: submission)
-                self?.delegate?.addedSubmission(record: recordDetailViewModel)
+                if let submission = submission {
+                    let recordDetailViewModel = RecordDetailViewModel.init(record: submission)
+                    self?.delegate?.addedSubmission(record: recordDetailViewModel)
+                }
             case .failure(let error):
                 self?.delegate?.failedSubmission(error: error)
             }

--- a/QStreak/View Controllers/Record List/RecordListViewModel.swift
+++ b/QStreak/View Controllers/Record List/RecordListViewModel.swift
@@ -50,6 +50,8 @@ class RecordListViewModel {
         sessionProvider.request(type: PagedSubmissions.self, service: QstreakService.getSubmissions(page: currentPage)) { [weak self] result in
             switch result {
             case let .success(response):
+                guard let response = response else { return }
+
                 DispatchQueue.main.async {
                     self?.currentPage += 1
                     self?.totalPages = response.totalPages

--- a/QStreak/View Controllers/View Record/RecordDetailViewController.storyboard
+++ b/QStreak/View Controllers/View Record/RecordDetailViewController.storyboard
@@ -2,7 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="jj0-bc-JGM">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -140,6 +140,14 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0HY-aJ-AJ9" userLabel="Delete Button">
+                                <rect key="frame" x="185" y="751" width="45" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Delete"/>
+                                <connections>
+                                    <action selector="deleteButtonTapped:" destination="jj0-bc-JGM" eventType="touchUpInside" id="Zcr-K2-w9b"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <viewLayoutGuide key="safeArea" id="jPV-bb-E0n"/>

--- a/QStreak/View Controllers/View Record/RecordDetailViewController.swift
+++ b/QStreak/View Controllers/View Record/RecordDetailViewController.swift
@@ -43,7 +43,6 @@ class RecordDetailViewController: UIViewController {
         let viewController = recordDetailStoryboard.instantiateViewController(identifier: "RecordDetailViewController") as? RecordDetailViewController
 
         viewController?.viewModel = viewModel
-
         viewController?.comingFromCreation = comingFromCreation
 
         return viewController
@@ -52,8 +51,14 @@ class RecordDetailViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        viewModel.delegate = self
+
         setupNavBar()
         setupViews()
+    }
+
+    @IBAction private func deleteButtonTapped(_ sender: Any) {
+        viewModel.deleteButtonTapped()
     }
 
     private func setupViews() {
@@ -67,7 +72,6 @@ class RecordDetailViewController: UIViewController {
         activityLabel.text = viewModel.record.destinations
                                 .map { $0.name }
                                 .joined(separator: ", ")
-
     }
 
     private func setupNavBar() {
@@ -83,8 +87,29 @@ class RecordDetailViewController: UIViewController {
     }
 
     @objc private func backToDashboard(sender: UIBarButtonItem) {
-        let recordListStoryboard = UIStoryboard(name: String(describing: RecordListViewController.self), bundle: nil)
-        let recordListViewController = recordListStoryboard.instantiateViewController(withIdentifier: String(describing: RecordListViewController.self))
-        self.navigationController?.pushViewController(recordListViewController, animated: true)
+        redirectToDashboard()
+    }
+
+    func redirectToDashboard() {
+        DispatchQueue.main.async {
+             let recordListStoryboard = UIStoryboard(name: String(describing: RecordListViewController.self), bundle: nil)
+             let recordListViewController = recordListStoryboard.instantiateViewController(withIdentifier: String(describing: RecordListViewController.self))
+             self.navigationController?.pushViewController(recordListViewController, animated: true)
+        }
+    }
+}
+
+extension RecordDetailViewController: RecordDetailViewModelDelegate {
+    func submissionDeletionSuccess() {
+        redirectToDashboard()
+    }
+
+    func submissionDeletionFailure(error: NetworkError) {
+        DispatchQueue.main.async {
+            let alert = UIAlertController(title: self.viewModel.alertTitleText, message: error.message, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: self.viewModel.alertDismissButtonText, style: .default))
+
+            self.present(alert, animated: true, completion: nil)
+        }
     }
 }

--- a/QStreak/View Controllers/View Record/RecordDetailViewModel.swift
+++ b/QStreak/View Controllers/View Record/RecordDetailViewModel.swift
@@ -8,13 +8,36 @@
 
 import Foundation
 
+protocol RecordDetailViewModelDelegate: AnyObject {
+    func submissionDeletionSuccess()
+    func submissionDeletionFailure(error: NetworkError)
+}
+
 class RecordDetailViewModel {
 
     // MARK: - Properties
 
+    let alertTitleText = "Unable to delete submission"
+    let alertDismissButtonText =  "OK"
+
     let record: Submission
+
+    let sessionProvider = URLSessionProvider()
+
+    weak var delegate: RecordDetailViewModelDelegate?
 
     init(record: Submission) {
         self.record = record
+    }
+
+    func deleteButtonTapped() {
+        sessionProvider.request(type: Submission.self, service: QstreakService.deleteSubmission(submissionId: record.submissionID)) { [weak self] result in
+            switch result {
+            case .success:
+                self?.delegate?.submissionDeletionSuccess()
+            case .failure(let error):
+                self?.delegate?.submissionDeletionFailure(error: error)
+            }
+        }
     }
 }


### PR DESCRIPTION
Add a "delete" button to the submission detail view page and fire off corresponding API call when clicked.